### PR TITLE
Add weak matching to Entity.get_relationship/s

### DIFF
--- a/addons/gecs/entity.gd
+++ b/addons/gecs/entity.gd
@@ -201,7 +201,7 @@ func remove_relationships(_relationships: Array):
 ## Retrieves a specific [Relationship] from the entity.
 ## [param relationship] The [Relationship] to retrieve.
 ## [param return] - The FIRST matching [Relationship] if it exists, otherwise `null` or `[]` if single = false
-func get_relationship(relationship: Relationship, single = true):
+func get_relationship(relationship: Relationship, single = true, weak = false):
 	var results = []
 	var to_remove = []
 	for rel in relationships:
@@ -209,7 +209,7 @@ func get_relationship(relationship: Relationship, single = true):
 		if not rel.valid():
 			to_remove.append(rel)
 			continue
-		if rel.matches(relationship):
+		if rel.matches(relationship, weak):
 			if single:
 				return rel
 			results.append(rel)
@@ -227,14 +227,14 @@ func get_relationship(relationship: Relationship, single = true):
 ## Retrieves [Relationship]s from the entity.
 ## [param relationship] The [Relationship]s to retrieve.
 ## [param return] - All matching [Relationship]s if it exists, otherwise `null`.
-func get_relationships(relationship: Relationship) -> Array:
-	return get_relationship(relationship, false)
+func get_relationships(relationship: Relationship, weak = false) -> Array:
+	return get_relationship(relationship, false, weak)
 
 
 ## Checks if the entity has a specific relationship.[br]
 ## [param relationship] The [Relationship] to check for.
-func has_relationship(relationship: Relationship) -> bool:
-	return get_relationship(relationship) != null
+func has_relationship(relationship: Relationship, weak = false) -> bool:
+	return get_relationship(relationship, true, weak) != null
 
 
 ## ##################################

--- a/addons/gecs/relationship.gd
+++ b/addons/gecs/relationship.gd
@@ -61,7 +61,7 @@ func _init(_relation = null, _target = null):
 ## Checks if this relationship matches another relationship.
 ## [param other]: The [Relationship] to compare with.
 ## [return]: `true` if both the relation and target match, `false` otherwise.
-func matches(other: Relationship) -> bool:
+func matches(other: Relationship, weak = false) -> bool:
 	var rel_match = false
 	var target_match = false
 
@@ -70,8 +70,11 @@ func matches(other: Relationship) -> bool:
 		# If either relation is null, consider it a match (wildcard)
 		rel_match = true
 	else:
-		# Use the equals method from the Component class to compare relations
-		rel_match = relation.equals(other.relation)
+		if weak:
+			rel_match = relation.resource_path == other.relation.resource_path
+		else:
+			# Use the equals method from the Component class to compare relations
+			rel_match = relation.equals(other.relation)
 
 	# Compare targets
 	if other.target == null or target == null:

--- a/addons/gecs/tests/test_relationships.gd
+++ b/addons/gecs/tests/test_relationships.gd
@@ -185,6 +185,16 @@ func test_archetype_and_entity():
 	assert_bool(entities_that_like_pizza.has(e_bob)).is_true()  # bob only likes pizza
 	assert_bool(entities_that_like_pizza.has(e_heather)).is_true()  # heather likes food so of course she likes pizza
 
+func test_weak_relationship_matching():
+	var heather_eats_apples = e_heather.get_relationship(Relationship.new(C_Eats.new(), e_apple), true, true)
+	var heather_has_eats_apples = e_heather.has_relationship(Relationship.new(C_Eats.new(), e_apple), true)
+	var bob_doesnt_eat_apples = e_bob.get_relationship(Relationship.new(C_Eats.new(), e_apple), true, true)
+	var bob_has_eats_apples = e_bob.has_relationship(Relationship.new(C_Eats.new(), e_apple), true)
+	assert_bool(heather_eats_apples != null).is_true()  # heather eats apples
+	assert_bool(heather_has_eats_apples).is_true()  # heather eats apples
+	assert_bool(bob_doesnt_eat_apples == null).is_true()  # bob doesn't eat apples
+	assert_bool(bob_has_eats_apples).is_false()  # bob doesn't eat apples
+
 # # FIXME: This is not working
 # func test_reverse_relationships_a():
 


### PR DESCRIPTION
This allows relationships with non-tag relations to be matched solely on `resource_path`.

If you have a non-tag relation component with data, `C_SomeRelation`, then:

```py
entity.get_relationships(Relationship.new(C_SomeRelation.new(), ECS.wildcard)
```

Wont match any relationships with non-default property values. You can only find relationships where you already know all of the property values. With this change:

```py
entity.get_relationships(Relationship.new(C_SomeRelation.new(), ECS.wildcard, true)
```

Any `C_SomeRelation` relationship will be returned.

This is a backwards-compatible change.

1. `Relationship.matches(other: Relationship, weak = false)`

This introduces a condition that allows matching relations solely on `resource_path`:

```py
		if weak:
			rel_match = relation.resource_path == other.relation.resource_path
		else:
			# Use the equals method from the Component class to compare relations
			rel_match = relation.equals(other.relation)
```

2. `Entity.get_relationship(relationship: Relationship, single = true, weak = false)`

This passes the weak parameter along to `Relationship.matches`

3. `Entity.get_relationships(relationship: Relationship, weak = false)`

4. `Entity.has_relationship(relationship: Relationship, weak = false)`


