### PR TITLE
Check if relationship target is valid in added/removed hooks

### DIFF
--- a/addons/gecs/world.gd
+++ b/addons/gecs/world.gd
@@ -541,7 +541,7 @@ func _on_entity_relationship_added(entity: Entity, relationship: Relationship) -
 	relationship_entity_index[key].append(entity)
 
 	# Index the reverse relationship
-	if relationship.target is Entity:
+	if is_instance_valid(relationship.target) and relationship.target is Entity:
 		var rev_key = "reverse_" + key
 		if not reverse_relationship_index.has(rev_key):
 			reverse_relationship_index[rev_key] = []
@@ -558,7 +558,7 @@ func _on_entity_relationship_removed(entity: Entity, relationship: Relationship)
 	if relationship_entity_index.has(key):
 		relationship_entity_index[key].erase(entity)
 
-	if relationship.target is Entity:
+	if is_instance_valid(relationship.target) and relationship.target is Entity:
 		var rev_key = "reverse_" + key
 		if reverse_relationship_index.has(rev_key):
 			reverse_relationship_index[rev_key].erase(relationship.target)


### PR DESCRIPTION
When an entity is removed, the relationships it partakes in become stale/invalid.

If a relationship where the target has already been freed is removed from the source entity, then GDScript will complain that we're doing an `is Entity` check on a value that's already been freed.

> Left operand of 'is' is a previously freed instance.

This adds an `is_instance_valid(target)` check to the conditional to avoid crashing out in this case.

All tests continue to pass. 