### PR TITLE
Fix component-add signal fire before the connecting setup 

### DIFF
--- a/addons/gecs/entity.gd
+++ b/addons/gecs/entity.gd
@@ -67,6 +67,9 @@ func _ready() -> void:
 
 func _initialize():
 	_entityLogger.trace("Entity Initializing Components: ", self.name)
+	
+	for preadd_component in components.values():
+		component_added.emit(self, preadd_component)
 
 	# Add components defined in code
 	component_resources.append_array(define_components())

--- a/addons/gecs/tests/core/test_observers.gd
+++ b/addons/gecs/tests/core/test_observers.gd
@@ -1,0 +1,65 @@
+extends GdUnitTestSuite
+
+const TestA = preload("res://addons/gecs/tests/entities/e_test_a.gd")
+const TestB = preload("res://addons/gecs/tests/entities/e_test_b.gd")
+const TestC = preload("res://addons/gecs/tests/entities/e_test_c.gd")
+
+const C_TestA = preload("res://addons/gecs/tests/components/c_test_a.gd")
+const C_TestB = preload("res://addons/gecs/tests/components/c_test_b.gd")
+const C_TestC = preload("res://addons/gecs/tests/components/c_test_c.gd")
+const C_TestD = preload("res://addons/gecs/tests/components/c_test_d.gd")
+const C_TestE = preload("res://addons/gecs/tests/components/c_test_e.gd")
+
+const TestSystemA = preload("res://addons/gecs/tests/systems/s_test_a.gd")
+const TestSystemB = preload("res://addons/gecs/tests/systems/s_test_b.gd")
+const TestSystemC = preload("res://addons/gecs/tests/systems/s_test_c.gd")
+
+var runner: GdUnitSceneRunner
+var world: World
+
+
+func before():
+	runner = scene_runner("res://addons/gecs/tests/test_scene.tscn")
+	world = runner.get_property("world")
+	ECS.world = world
+
+
+func after_test():
+	world.purge(false)
+	
+func test_observer_receive_component_changed():
+	# Create entities with the required components
+	var entity_a = TestA.new()
+	entity_a.name = "a"
+	entity_a.add_component(C_TestA.new())
+
+	var entity_b = TestB.new()
+	entity_b.name = "b"
+	entity_b.add_component(C_TestA.new())
+	entity_b.add_component(C_TestB.new())
+
+	
+
+	# Add  some entities before systems
+	world.add_entities([entity_a, entity_b])
+
+	world.add_system(TestSystemA.new())
+	#world.add_system(TestSystemB.new())
+	#world.add_system(TestSystemC.new())
+	var test_a_observer = TestAObserver.new()
+	world.add_observer(test_a_observer)
+
+	# Run the systems once
+	print('process 1st')
+	world.process(0.1)
+
+	# Check the event_count
+	assert_int(test_a_observer.event_count).is_equal(1)
+	
+	# Run the systems again
+	print('process 2nd')
+	world.process(0.1)
+
+	# Check the event_count
+	assert_int(test_a_observer.event_count).is_equal(2)
+	

--- a/addons/gecs/tests/systems/o_test_a.gd
+++ b/addons/gecs/tests/systems/o_test_a.gd
@@ -6,6 +6,8 @@ extends Observer
 const C_TestA = preload("res://addons/gecs/tests/components/c_test_a.gd")
 const C_TestB = preload("res://addons/gecs/tests/components/c_test_b.gd")
 
+var event_count := 0
+
 
 ## The component to watch for changes
 func watch() -> Resource:
@@ -23,4 +25,5 @@ func on_component_changed(
 	entity: Entity, component: Resource, property: String, old_value: Variant, new_value: Variant
 ) -> void:
 	# Set the transfrom from the component to the entity
-	print("We changed!")
+	print("We changed!", entity.name , component.value)
+	event_count += 1

--- a/addons/gecs/tests/systems/s_test_a.gd
+++ b/addons/gecs/tests/systems/s_test_a.gd
@@ -23,6 +23,7 @@ func query():
 
 
 func process(entity: Entity, delta: float):
-	var a = entity.get_component(C_TestA)
+	var a = entity.get_component(C_TestA) as C_TestA
 	a.value += 1
-	print("TestASystem: ", a.value)
+	a.property_changed.emit(a, 'value', null, null)
+	print("TestASystem: ", entity.name, a.value)

--- a/addons/gecs/world.gd
+++ b/addons/gecs/world.gd
@@ -180,14 +180,10 @@ func update_pause_state(paused: bool) -> void:
 ## world.add_entity(other_entity, [component_a, component_b])
 ## [/codeblock]
 func add_entity(entity: Entity, components = null, add_to_tree = true) -> void:
-	if add_to_tree and not entity.is_inside_tree():
-		get_node(entity_nodes_root).add_child(entity)
 	# Update index
 	_worldLogger.debug("add_entity Adding Entity to World: ", entity)
 	entities.append(entity)
 	entity_added.emit(entity)
-	for component_key in entity.components.keys():
-		_add_entity_to_index(entity, component_key)
 
 	# Connect to entity signals for components so we can track global component state
 	if not entity.component_added.is_connected(_on_entity_component_added):
@@ -198,6 +194,10 @@ func add_entity(entity: Entity, components = null, add_to_tree = true) -> void:
 		entity.relationship_added.connect(_on_entity_relationship_added)
 	if not entity.relationship_removed.is_connected(_on_entity_relationship_removed):
 		entity.relationship_removed.connect(_on_entity_relationship_removed)
+	
+	# add to the tree after setup signal connecting	
+	if add_to_tree and not entity.is_inside_tree():
+		get_node(entity_nodes_root).add_child(entity)
 
 	if components:
 		entity.add_components(components)


### PR DESCRIPTION
bug from https://discord.com/channels/1351956875717120124/1351957683720425538/1418578896646963262.

the issue is the component-add signal fired before connection setup in add_entity. 
1. i relocate the code which add the entity to scene tree to a point after setup connecting.
2.  for those pre-added components, emit the component-add signal after entity is ready in scene tree.
3. remove code to avoid duplicate components/entities in cache.
4. add observer testcase and it success. 
5. other testcases also keep success.

best wish.
wilburH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Observers now receive events for pre-existing components during initialization, ensuring consistent event flow.
  * Component change notifications are emitted properly, preventing missed updates when entities are added.
  * Improved debug output now includes entity names and values for clearer tracing.

* Tests
  * Added observer integration test validating event counts across multiple world ticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->