### PR TITLE
Fix an error with to_string() overriding wrong

### DIFF
--- a/addons/gecs/query_builder.gd
+++ b/addons/gecs/query_builder.gd
@@ -450,7 +450,7 @@ func is_empty() -> bool:
 	)
 
 
-func to_string() -> String:
+func _to_string() -> String:
 	var parts = []
 	
 	if not _all_components.is_empty():


### PR DESCRIPTION
QueryBuilder overrides the method `to_string` which comes from the native class `Object`. Godot warns, which is treated as an error, that it won't be called by the engine and may not work as expected.

I updated the code to use `_to_string` which is the recommended way to override it. I believe it's still correct to call `to_string` and that may call `_to_string`. I'll contribute some more things and if I come across that being wrong I'll come back to this PR to explicitly say what the right way to use it is. So far, it doesn't seem like it's being used anywhere though. So we're all good!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the visibility of a query builder method to be internal/private, aligning it with internal usage patterns while preserving behavior and output.
  * Standardized internal formatting helpers without changing their functionality.

* **Chores**
  * Minor internal API cleanup to reduce surface area.

Note: No user-facing changes. Developers with custom integrations that referenced the previously public method may need to update their calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->