### PR TITLE
Remove unused QueryBuilder pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GECS Changelog
 
+## [Unreleased]
+
+### Removed
+- Removed the unused QueryBuilder pooling infrastructure; `World.query` now always creates a fresh builder while retaining cache invalidation wiring for clarity and predictable lifecycle management.
+
 ## [5.0.0] - 2025-10-15 - Major ECS Overhaul & Performance Awesomeness (Some Small Breaking Changes)
 
 **GECS v5.0.0 is a major release with massive performance improvements, API simplification, and relationship system overhaul.**


### PR DESCRIPTION
## Summary
- remove the unused QueryBuilder pooling logic from World.query so builders are always freshly constructed
- document the removal in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69091e6a4b0883279d2bcfa383fe3b8d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed QueryBuilder pooling infrastructure from the ECS world. Query operations now create fresh builder instances instead of reusing pooled ones, improving predictability and lifecycle clarity while maintaining cache invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->