### PR TITLE
Implement FLECS-style timer and tick source system

### DIFF
--- a/addons/gecs/ecs/accumulated_tick_source.gd
+++ b/addons/gecs/ecs/accumulated_tick_source.gd
@@ -37,13 +37,14 @@ var tick_count: int = 0
 
 ## Update the tick source with frame delta
 ## Returns the accumulated time when it's time to tick, 0.0 otherwise
+## Carries forward extra time to prevent drift during lag spikes
 func update(delta: float) -> float:
 	accumulated_time += delta
 
 	if accumulated_time >= interval:
 		tick_count += 1
-		last_delta = accumulated_time  # Actual accumulated time
-		accumulated_time = 0.0
+		last_delta = accumulated_time  # Return full accumulated time
+		accumulated_time -= interval  # Carry forward extra time
 	else:
 		last_delta = 0.0  # No tick this frame
 

--- a/addons/gecs/ecs/accumulated_tick_source.gd
+++ b/addons/gecs/ecs/accumulated_tick_source.gd
@@ -1,0 +1,57 @@
+## AccumulatedTickSource
+##
+## Time-based tick source that fires at intervals but returns the actual accumulated time.
+##
+## Similar to IntervalTickSource, but returns the actual accumulated delta instead of
+## the fixed interval. Useful when you need to account for time drift or variable frame rates.
+##
+## [b]Example:[/b]
+## [codeblock]
+## # In world setup
+## var physics_tick = AccumulatedTickSource.new()
+## physics_tick.interval = 0.02  # ~50 FPS
+## ECS.world.register_tick_source(physics_tick, "physics-tick")
+##
+## # In system
+## class_name PhysicsSystem extends System
+##
+## func tick() -> TickSource:
+##     return ECS.world.get_tick_source("physics-tick")
+##
+## func process(entities: Array[Entity], components: Array, delta: float) -> void:
+##     # delta will be the actual accumulated time (e.g., 0.021 if slightly behind)
+##     apply_physics(entities, delta)
+## [/codeblock]
+class_name AccumulatedTickSource
+extends TickSource
+
+## The interval in seconds between ticks
+@export var interval: float = 1.0
+
+## Accumulated time since last tick
+var accumulated_time: float = 0.0
+
+## Total number of ticks that have occurred
+var tick_count: int = 0
+
+
+## Update the tick source with frame delta
+## Returns the accumulated time when it's time to tick, 0.0 otherwise
+func update(delta: float) -> float:
+	accumulated_time += delta
+
+	if accumulated_time >= interval:
+		tick_count += 1
+		last_delta = accumulated_time  # Actual accumulated time
+		accumulated_time = 0.0
+	else:
+		last_delta = 0.0  # No tick this frame
+
+	return last_delta
+
+
+## Reset tick source state
+func reset() -> void:
+	super.reset()
+	accumulated_time = 0.0
+	tick_count = 0

--- a/addons/gecs/ecs/interval_tick_source.gd
+++ b/addons/gecs/ecs/interval_tick_source.gd
@@ -1,0 +1,57 @@
+## IntervalTickSource
+##
+## Time-based tick source that fires at fixed intervals.
+##
+## Returns a fixed interval delta when the accumulated time exceeds the interval.
+## Useful for systems that need to run at specific time intervals (e.g., every 1 second).
+##
+## [b]Example:[/b]
+## [codeblock]
+## # In world setup
+## var spawner_tick = IntervalTickSource.new()
+## spawner_tick.interval = 1.0  # Tick every second
+## ECS.world.register_tick_source(spawner_tick, "spawner-tick")
+##
+## # In system
+## class_name SpawnerSystem extends System
+##
+## func tick() -> TickSource:
+##     return ECS.world.get_tick_source("spawner-tick")
+##
+## func process(entities: Array[Entity], components: Array, delta: float) -> void:
+##     # This runs every 1 second with delta = 1.0
+##     spawn_enemy()
+## [/codeblock]
+class_name IntervalTickSource
+extends TickSource
+
+## The interval in seconds between ticks
+@export var interval: float = 1.0
+
+## Accumulated time since last tick
+var accumulated_time: float = 0.0
+
+## Total number of ticks that have occurred
+var tick_count: int = 0
+
+
+## Update the tick source with frame delta
+## Returns the fixed interval when it's time to tick, 0.0 otherwise
+func update(delta: float) -> float:
+	accumulated_time += delta
+
+	if accumulated_time >= interval:
+		tick_count += 1
+		accumulated_time -= interval
+		last_delta = interval  # Fixed interval
+	else:
+		last_delta = 0.0  # No tick this frame
+
+	return last_delta
+
+
+## Reset tick source state
+func reset() -> void:
+	super.reset()
+	accumulated_time = 0.0
+	tick_count = 0

--- a/addons/gecs/ecs/interval_tick_source.gd
+++ b/addons/gecs/ecs/interval_tick_source.gd
@@ -37,16 +37,18 @@ var tick_count: int = 0
 
 ## Update the tick source with frame delta
 ## Returns the fixed interval when it's time to tick, 0.0 otherwise
+## Handles lag spikes by processing all pending intervals in a single frame
 func update(delta: float) -> float:
 	accumulated_time += delta
 
-	if accumulated_time >= interval:
+	# Process all pending intervals (handles lag spikes and pauses)
+	var ticked := false
+	while accumulated_time >= interval:
 		tick_count += 1
 		accumulated_time -= interval
-		last_delta = interval  # Fixed interval
-	else:
-		last_delta = 0.0  # No tick this frame
+		ticked = true
 
+	last_delta = interval if ticked else 0.0
 	return last_delta
 
 

--- a/addons/gecs/ecs/rate_filter_tick_source.gd
+++ b/addons/gecs/ecs/rate_filter_tick_source.gd
@@ -1,0 +1,71 @@
+## RateFilterTickSource
+##
+## Frame-based tick source that samples another tick source at a specific rate.
+##
+## Ticks every Nth time the source ticks, accumulating the delta values.
+## Useful for creating hierarchical timing systems and deterministic frame-based execution.
+##
+## [b]Example:[/b]
+## [codeblock]
+## # In world setup
+## ECS.world.create_interval_tick_source(1.0, "second")
+## ECS.world.create_rate_filter(60, "second", "minute")  # Every 60 seconds
+##
+## # In system
+## class_name AutoSaveSystem extends System
+##
+## func tick() -> TickSource:
+##     return ECS.world.get_tick_source("minute")
+##
+## func process(entities: Array[Entity], components: Array, delta: float) -> void:
+##     # This runs every 60 seconds
+##     # delta will be the accumulated time from 60 ticks (~60 seconds)
+##     auto_save_game()
+## [/codeblock]
+##
+## [b]Note:[/b] The source tick source is NOT updated by this class - World updates
+## all tick sources in order, so we just read the source's last_delta from its update.
+class_name RateFilterTickSource
+extends TickSource
+
+## The number of source ticks to wait before ticking
+@export var rate: int = 60
+
+## The source tick source to sample (set by World.create_rate_filter)
+@export var source: TickSource
+
+## Internal counter for source ticks
+var tick_count: int = 0
+
+## Accumulated delta from source ticks
+var accumulated_delta: float = 0.0
+
+
+## Update the tick source
+## Samples the source's last_delta and ticks every Nth source tick
+## Returns the accumulated delta when it's time to tick, 0.0 otherwise
+func update(delta: float) -> float:
+	# NOTE: Source is NOT updated here - World updates all tick sources
+	# We just read the source's last_delta from its previous update
+
+	if source.last_delta > 0.0:  # Source ticked this frame
+		tick_count += 1
+		accumulated_delta += source.last_delta
+
+		if tick_count >= rate:
+			tick_count = 0
+			last_delta = accumulated_delta  # Return accumulated delta
+			accumulated_delta = 0.0
+		else:
+			last_delta = 0.0  # Not time to tick yet
+	else:
+		last_delta = 0.0  # Source didn't tick
+
+	return last_delta
+
+
+## Reset tick source state
+func reset() -> void:
+	super.reset()
+	tick_count = 0
+	accumulated_delta = 0.0

--- a/addons/gecs/ecs/system.gd
+++ b/addons/gecs/ecs/system.gd
@@ -183,9 +183,8 @@ func process(entities: Array[Entity], components: Array, delta: float) -> void:
 ## INTERNAL: Called by World.add_system() to initialize the system
 ## DO NOT CALL OR OVERRIDE - this is framework code
 func _internal_setup():
-	# Cache tick source if system defines one
-	if has_method("tick"):
-		_tick_source_cached = tick()
+	# Cache tick source - base returns null (fast path), overrides provide TickSource
+	_tick_source_cached = tick()
 
 	# Call user setup
 	setup()

--- a/addons/gecs/ecs/tick_source.gd
+++ b/addons/gecs/ecs/tick_source.gd
@@ -1,0 +1,41 @@
+## TickSource
+##
+## Base class for custom tick sources that control system execution timing.
+##
+## Tick sources determine when systems run and what delta value they receive.
+## The base implementation passes through the frame delta (default behavior).
+## Override [method update] to create custom timing behaviors.
+##
+## [b]Example (Custom tick source):[/b]
+## [codeblock]
+## class_name RandomTickSource extends TickSource
+##
+## var probability: float = 0.5
+##
+## func update(delta: float) -> float:
+##     if randf() < probability:
+##         last_delta = delta
+##     else:
+##         last_delta = 0.0  # Skip this frame
+##     return last_delta
+## [/codeblock]
+class_name TickSource
+extends Resource
+
+## The delta value from the last update (0.0 = didn't tick this frame)
+var last_delta: float = 0.0
+
+
+## Called every frame by World.process()
+## Must set last_delta and return it
+## [param delta] The frame delta time
+## [return] The delta value to pass to systems (0.0 to skip this frame)
+func update(delta: float) -> float:
+	last_delta = delta  # Pass through - override in subclasses
+	return last_delta
+
+
+## Reset tick source state
+## Override this to reset custom state variables
+func reset() -> void:
+	last_delta = 0.0

--- a/addons/gecs/ecs/world.gd
+++ b/addons/gecs/ecs/world.gd
@@ -102,6 +102,8 @@ var _perf_metrics := {
 }
 ## Tick source registry - maps name -> TickSource
 var _tick_sources: Dictionary = {}
+## Frame counter to ensure tick sources are only updated once per frame
+var _tick_sources_last_frame: int = -1
 
 
 ## Internal perf helper (debug only)
@@ -208,8 +210,11 @@ func process(delta: float, group: String = "") -> void:
 	# PERF: Reset frame metrics at start of processing step
 	perf_reset_frame()
 
-	# Update all tick sources (only if any exist to avoid overhead)
-	if not _tick_sources.is_empty():
+	# Update all tick sources ONCE per frame (only if any exist to avoid overhead)
+	# This prevents double-updating when processing multiple groups in the same frame
+	var current_frame = Engine.get_process_frames()
+	if not _tick_sources.is_empty() and _tick_sources_last_frame != current_frame:
+		_tick_sources_last_frame = current_frame
 		for tick_source in _tick_sources.values():
 			tick_source.update(delta)
 

--- a/addons/gecs/ecs/world.gd
+++ b/addons/gecs/ecs/world.gd
@@ -100,6 +100,8 @@ var _perf_metrics := {
 	"frame": {}, # Per-frame aggregated timings
 	"accum": {} # Long-lived totals (cleared manually)
 }
+## Tick source registry - maps name -> TickSource
+var _tick_sources: Dictionary = {}
 
 
 ## Internal perf helper (debug only)
@@ -205,11 +207,26 @@ func initialize():
 func process(delta: float, group: String = "") -> void:
 	# PERF: Reset frame metrics at start of processing step
 	perf_reset_frame()
+
+	# Update all tick sources (only if any exist to avoid overhead)
+	if not _tick_sources.is_empty():
+		for tick_source in _tick_sources.values():
+			tick_source.update(delta)
+
+	# Process systems
 	if systems_by_group.has(group):
 		var system_index = 0
 		for system in systems_by_group[group]:
 			if system.active:
-				system._handle(delta)
+				# Fast path: No tick source = pass through frame delta (zero overhead)
+				if system._tick_source_cached == null:
+					system._handle(delta)
+				else:
+					# Tick source path: check if we should run this frame
+					var system_delta = system._tick_source_cached.last_delta
+					if system_delta > 0.0:  # Only run if ticked
+						system._handle(system_delta)
+
 				if ECS.debug:
 					# Add execution order to last run data
 					system.lastRunData["execution_order"] = system_index
@@ -227,6 +244,78 @@ func update_pause_state(paused: bool) -> void:
 		for system in systems_by_group[group_key]:
 			# Check to see if the system is can process based on the process mode and paused state
 			system.paused = not system.can_process()
+
+
+#region Tick Sources
+
+## Register a tick source with a unique name.[br]
+## Asserts if name already exists to prevent accidental bugs.[br]
+## [param tick_source] The [TickSource] to register.[br]
+## [param name] The unique name for this tick source.[br]
+## [return] The registered tick source (for chaining).[br]
+## [b]Example:[/b]
+## [codeblock]
+## var my_tick = IntervalTickSource.new()
+## my_tick.interval = 1.0
+## ECS.world.register_tick_source(my_tick, "spawner-tick")
+## [/codeblock]
+func register_tick_source(tick_source: TickSource, name: String) -> TickSource:
+	assert(not _tick_sources.has(name), "TickSource '%s' already registered!" % name)
+	_tick_sources[name] = tick_source
+	return tick_source
+
+
+## Get existing tick source by name.[br]
+## Returns null if not found.[br]
+## [param name] The name of the tick source to get.[br]
+## [return] The [TickSource] or null if not found.[br]
+## [b]Example:[/b]
+## [codeblock]
+## class_name MySystem extends System
+##
+## func tick() -> TickSource:
+##     return ECS.world.get_tick_source('spawner-tick')
+## [/codeblock]
+func get_tick_source(name: String) -> TickSource:
+	return _tick_sources.get(name)
+
+
+## Convenience: Create and register an interval tick source.[br]
+## [param interval] The interval in seconds between ticks.[br]
+## [param name] The unique name for this tick source.[br]
+## [return] The created tick source.[br]
+## [b]Example:[/b]
+## [codeblock]
+## # In world setup (_ready, autoload, etc.)
+## ECS.world.create_interval_tick_source(1.0, 'spawner-tick')
+## [/codeblock]
+func create_interval_tick_source(interval: float, name: String) -> TickSource:
+	var ts = IntervalTickSource.new()
+	ts.interval = interval
+	return register_tick_source(ts, name)
+
+
+## Convenience: Create and register a rate filter tick source.[br]
+## [param rate] The number of source ticks to wait before ticking.[br]
+## [param source_name] The name of the source tick source.[br]
+## [param name] The unique name for this tick source.[br]
+## [return] The created tick source.[br]
+## [b]Example:[/b]
+## [codeblock]
+## # In world setup
+## ECS.world.create_interval_tick_source(1.0, 'second')
+## ECS.world.create_rate_filter(60, 'second', 'minute')  # Every 60 seconds
+## [/codeblock]
+func create_rate_filter(rate: int, source_name: String, name: String) -> TickSource:
+	var source = get_tick_source(source_name)
+	assert(source != null, "Source tick source '%s' not found!" % source_name)
+
+	var rf = RateFilterTickSource.new()
+	rf.rate = rate
+	rf.source = source
+	return register_tick_source(rf, name)
+
+#endregion Tick Sources
 
 
 ## Adds a single [Entity] to the world.[br]

--- a/addons/gecs/tests/core/test_counting_system.gd
+++ b/addons/gecs/tests/core/test_counting_system.gd
@@ -1,0 +1,13 @@
+extends System
+
+# Test system that counts how many times it runs
+
+var run_count: int = 0
+
+
+func tick() -> TickSource:
+	return ECS.world.get_tick_source("test-tick") if ECS.world.get_tick_source("test-tick") else ECS.world.get_tick_source("shared-tick")
+
+
+func process(entities: Array[Entity], components: Array, delta: float) -> void:
+	run_count += 1

--- a/addons/gecs/tests/core/test_tick_source_system.gd
+++ b/addons/gecs/tests/core/test_tick_source_system.gd
@@ -1,0 +1,10 @@
+extends System
+
+# Test system that uses a tick source
+
+func tick() -> TickSource:
+	return ECS.world.get_tick_source("test-tick")
+
+
+func process(entities: Array[Entity], components: Array, delta: float) -> void:
+	pass

--- a/addons/gecs/tests/core/test_tick_sources.gd
+++ b/addons/gecs/tests/core/test_tick_sources.gd
@@ -1,0 +1,335 @@
+extends GdUnitTestSuite
+
+var runner: GdUnitSceneRunner
+var world: World
+
+
+func before():
+	runner = scene_runner("res://addons/gecs/tests/test_scene.tscn")
+	world = runner.get_property("world")
+	ECS.world = world
+
+
+func after_test():
+	if world:
+		world.purge(false)
+
+
+#region Base TickSource Tests
+
+func test_tick_source_base():
+	var tick_source = TickSource.new()
+
+	# Base implementation should pass through delta
+	var result = tick_source.update(0.016)
+	assert_float(result).is_equal(0.016)
+	assert_float(tick_source.last_delta).is_equal(0.016)
+
+	# Reset should clear last_delta
+	tick_source.reset()
+	assert_float(tick_source.last_delta).is_equal(0.0)
+
+
+#endregion Base TickSource Tests
+
+#region IntervalTickSource Tests
+
+func test_interval_tick_source_basic():
+	var tick_source = IntervalTickSource.new()
+	tick_source.interval = 1.0
+
+	# First update - not enough time accumulated
+	var result = tick_source.update(0.5)
+	assert_float(result).is_equal(0.0)
+	assert_float(tick_source.last_delta).is_equal(0.0)
+	assert_int(tick_source.tick_count).is_equal(0)
+
+	# Second update - now we should tick
+	result = tick_source.update(0.5)
+	assert_float(result).is_equal(1.0)  # Fixed interval
+	assert_float(tick_source.last_delta).is_equal(1.0)
+	assert_int(tick_source.tick_count).is_equal(1)
+
+
+func test_interval_tick_source_multiple_ticks():
+	var tick_source = IntervalTickSource.new()
+	tick_source.interval = 0.1
+
+	# Accumulate enough time for multiple ticks
+	for i in range(5):
+		tick_source.update(0.1)
+
+	assert_int(tick_source.tick_count).is_equal(5)
+
+
+func test_interval_tick_source_reset():
+	var tick_source = IntervalTickSource.new()
+	tick_source.interval = 1.0
+
+	tick_source.update(0.5)
+	tick_source.reset()
+
+	assert_float(tick_source.accumulated_time).is_equal(0.0)
+	assert_int(tick_source.tick_count).is_equal(0)
+	assert_float(tick_source.last_delta).is_equal(0.0)
+
+
+#endregion IntervalTickSource Tests
+
+#region AccumulatedTickSource Tests
+
+func test_accumulated_tick_source_basic():
+	var tick_source = AccumulatedTickSource.new()
+	tick_source.interval = 1.0
+
+	# First update - not enough time
+	var result = tick_source.update(0.5)
+	assert_float(result).is_equal(0.0)
+	assert_int(tick_source.tick_count).is_equal(0)
+
+	# Second update - should tick with accumulated time
+	result = tick_source.update(0.6)  # Total: 1.1
+	assert_float(result).is_equal(1.1)  # Actual accumulated time
+	assert_float(tick_source.last_delta).is_equal(1.1)
+	assert_int(tick_source.tick_count).is_equal(1)
+
+
+func test_accumulated_tick_source_resets_accumulation():
+	var tick_source = AccumulatedTickSource.new()
+	tick_source.interval = 1.0
+
+	tick_source.update(0.5)
+	tick_source.update(0.6)  # Ticks with 1.1
+
+	# After tick, accumulated_time should reset
+	assert_float(tick_source.accumulated_time).is_equal(0.0)
+
+
+#endregion AccumulatedTickSource Tests
+
+#region RateFilterTickSource Tests
+
+func test_rate_filter_basic():
+	var source = IntervalTickSource.new()
+	source.interval = 0.1
+
+	var filter = RateFilterTickSource.new()
+	filter.rate = 3
+	filter.source = source
+
+	# Tick source 3 times
+	for i in range(3):
+		source.update(0.1)
+		filter.update(0.1)
+
+	# Filter should tick on the 3rd source tick
+	assert_int(filter.tick_count).is_equal(0)  # Reset after ticking
+	assert_float(filter.last_delta).is_equal(0.3)  # Accumulated delta from 3 ticks
+
+
+func test_rate_filter_only_counts_source_ticks():
+	var source = IntervalTickSource.new()
+	source.interval = 1.0
+
+	var filter = RateFilterTickSource.new()
+	filter.rate = 2
+	filter.source = source
+
+	# Update both with small deltas (source won't tick)
+	for i in range(5):
+		source.update(0.1)
+		filter.update(0.1)
+
+	# Filter should not have ticked because source didn't tick enough
+	assert_int(filter.tick_count).is_equal(0)
+
+
+func test_rate_filter_reset():
+	var source = IntervalTickSource.new()
+	source.interval = 0.1
+
+	var filter = RateFilterTickSource.new()
+	filter.rate = 2
+	filter.source = source
+
+	source.update(0.1)
+	filter.update(0.1)
+
+	filter.reset()
+	assert_int(filter.tick_count).is_equal(0)
+	assert_float(filter.accumulated_delta).is_equal(0.0)
+
+
+#endregion RateFilterTickSource Tests
+
+#region World Integration Tests
+
+func test_register_tick_source():
+	var tick_source = IntervalTickSource.new()
+	tick_source.interval = 1.0
+
+	world.register_tick_source(tick_source, "test-tick")
+
+	var retrieved = world.get_tick_source("test-tick")
+	assert_object(retrieved).is_equal(tick_source)
+
+
+func test_register_duplicate_tick_source_asserts():
+	var tick_source1 = IntervalTickSource.new()
+	var tick_source2 = IntervalTickSource.new()
+
+	world.register_tick_source(tick_source1, "test-tick")
+
+	# This should assert - but we can't easily test assertions in GdUnit4
+	# Just document that this is expected behavior
+	# world.register_tick_source(tick_source2, "test-tick")
+
+
+func test_get_nonexistent_tick_source():
+	var result = world.get_tick_source("nonexistent")
+	assert_object(result).is_null()
+
+
+func test_create_interval_tick_source():
+	var tick_source = world.create_interval_tick_source(1.0, "spawner")
+
+	assert_object(tick_source).is_not_null()
+	assert_object(tick_source).is_instanceof(IntervalTickSource)
+	assert_float(tick_source.interval).is_equal(1.0)
+
+	# Should be retrievable
+	var retrieved = world.get_tick_source("spawner")
+	assert_object(retrieved).is_equal(tick_source)
+
+
+func test_create_rate_filter():
+	world.create_interval_tick_source(1.0, "second")
+	var filter = world.create_rate_filter(60, "second", "minute")
+
+	assert_object(filter).is_not_null()
+	assert_object(filter).is_instanceof(RateFilterTickSource)
+	assert_int(filter.rate).is_equal(60)
+
+
+#endregion World Integration Tests
+
+#region System Integration Tests
+
+func test_system_with_tick_source():
+	# Create a test system that uses a tick source
+	var test_system = System.new()
+	test_system.set_script(load("res://addons/gecs/tests/core/test_tick_source_system.gd"))
+
+	# Create tick source
+	world.create_interval_tick_source(1.0, "test-tick")
+
+	# Add system to world (this triggers _internal_setup which caches tick source)
+	world.add_system(test_system)
+
+	# System should have cached tick source
+	assert_object(test_system._tick_source_cached).is_not_null()
+	assert_object(test_system._tick_source_cached).is_instanceof(IntervalTickSource)
+
+
+func test_system_without_tick_source():
+	var test_system = System.new()
+
+	world.add_system(test_system)
+
+	# System should have null tick source (uses frame delta)
+	assert_object(test_system._tick_source_cached).is_null()
+
+
+func test_world_process_updates_tick_sources():
+	var tick_source = world.create_interval_tick_source(1.0, "test")
+
+	# Process world
+	world.process(0.5, "")
+
+	# Tick source should have been updated
+	assert_float(tick_source.accumulated_time).is_equal(0.5)
+
+
+func test_system_only_runs_when_tick_source_ticks():
+	# Create a counting system
+	var test_system = System.new()
+	test_system.set_script(load("res://addons/gecs/tests/core/test_counting_system.gd"))
+
+	# Create tick source with 1 second interval
+	world.create_interval_tick_source(1.0, "test-tick")
+
+	world.add_system(test_system)
+
+	# Process with small deltas (tick source won't tick)
+	for i in range(5):
+		world.process(0.1, "")
+
+	# System should not have run yet (0.5 seconds < 1.0 second)
+	assert_int(test_system.run_count).is_equal(0)
+
+	# Process with enough delta to trigger tick
+	world.process(0.5, "")
+
+	# System should have run once
+	assert_int(test_system.run_count).is_equal(1)
+
+
+#endregion System Integration Tests
+
+#region Synchronization Tests
+
+func test_multiple_systems_share_tick_source():
+	# Create two systems that use the same tick source
+	var system1 = System.new()
+	system1.set_script(load("res://addons/gecs/tests/core/test_counting_system.gd"))
+
+	var system2 = System.new()
+	system2.set_script(load("res://addons/gecs/tests/core/test_counting_system.gd"))
+
+	# Create shared tick source
+	world.create_interval_tick_source(1.0, "shared-tick")
+
+	world.add_system(system1)
+	world.add_system(system2)
+
+	# Both systems should reference the same tick source
+	assert_object(system1._tick_source_cached).is_equal(system2._tick_source_cached)
+
+	# Process to trigger tick
+	world.process(1.0, "")
+
+	# Both systems should have run
+	assert_int(system1.run_count).is_equal(1)
+	assert_int(system2.run_count).is_equal(1)
+
+
+#endregion Synchronization Tests
+
+#region Hierarchical Timing Tests
+
+func test_hierarchical_tick_sources():
+	# Create hierarchy: second -> minute -> hour
+	world.create_interval_tick_source(1.0, "second")
+	world.create_rate_filter(60, "second", "minute")
+	world.create_rate_filter(60, "minute", "hour")
+
+	var second_tick = world.get_tick_source("second")
+	var minute_tick = world.get_tick_source("minute")
+	var hour_tick = world.get_tick_source("hour")
+
+	# Process 60 seconds
+	for i in range(60):
+		world.process(1.0, "")
+
+	# Second should have ticked 60 times
+	assert_int(second_tick.tick_count).is_equal(60)
+
+	# Minute should have ticked once
+	assert_int(minute_tick.tick_count).is_equal(0)  # Reset after ticking
+	assert_float(minute_tick.last_delta).is_equal(60.0)
+
+	# Hour should not have ticked yet
+	assert_float(hour_tick.last_delta).is_equal(0.0)
+
+
+#endregion Hierarchical Timing Tests

--- a/example/systems/s_timed_spawner.gd
+++ b/example/systems/s_timed_spawner.gd
@@ -1,0 +1,41 @@
+## TimedSpawnerSystem
+##
+## Example system demonstrating tick source usage.
+## This system spawns entities at a fixed interval (every 2 seconds) instead of every frame.
+##
+## To use this system:
+## 1. Register the tick source in your world setup (e.g., in World's _ready or autoload):
+##    ECS.world.create_interval_tick_source(2.0, 'spawner-tick')
+##
+## 2. Add this system to your world
+##
+## 3. The system will only run every 2 seconds instead of every frame
+class_name TimedSpawnerSystem
+extends System
+
+@export var entity_scene: PackedScene
+
+var spawn_count: int = 0
+
+
+## Override tick() to specify which tick source to use
+func tick() -> TickSource:
+	return ECS.world.get_tick_source('spawner-tick')
+
+
+## This process method now only runs when the tick source ticks (every 2 seconds)
+## The delta value will be the tick source's delta (2.0 for IntervalTickSource)
+func process(_entities: Array[Entity], _components: Array, delta: float) -> void:
+	if not entity_scene:
+		return
+
+	spawn_count += 1
+	print("TimedSpawner: Spawning entity #%d (delta: %.2f)" % [spawn_count, delta])
+
+	call_deferred('_spawn_entity')
+
+
+func _spawn_entity():
+	if entity_scene:
+		var entity = entity_scene.instantiate() as Entity
+		ECS.world.add_entity(entity)

--- a/example/tick_source_setup_example.gd
+++ b/example/tick_source_setup_example.gd
@@ -1,0 +1,92 @@
+## Example: Tick Source Setup
+##
+## This script demonstrates how to set up tick sources for your GECS world.
+## Place this in your World node's _ready() method or in an autoload script.
+
+extends Node
+
+
+func _ready():
+	# Wait for world to be ready
+	await get_tree().process_frame
+
+	# Example 1: Simple interval tick source
+	# Creates a tick source that ticks every 2 seconds
+	ECS.world.create_interval_tick_source(2.0, 'spawner-tick')
+
+	# Example 2: Fast physics tick
+	# Creates a tick source for high-frequency updates (50 Hz)
+	ECS.world.create_interval_tick_source(0.02, 'physics-tick')
+
+	# Example 3: Hierarchical timing
+	# Create a chain of tick sources for time-based systems
+	ECS.world.create_interval_tick_source(1.0, 'second')        # Every second
+	ECS.world.create_rate_filter(60, 'second', 'minute')        # Every 60 seconds
+	ECS.world.create_rate_filter(60, 'minute', 'hour')          # Every 60 minutes
+	ECS.world.create_rate_filter(24, 'hour', 'day')             # Every 24 hours
+
+	# Example 4: Manual tick source registration
+	var custom_tick = AccumulatedTickSource.new()
+	custom_tick.interval = 0.5
+	ECS.world.register_tick_source(custom_tick, 'custom-tick')
+
+	print("Tick sources registered:")
+	print("  - spawner-tick: 2.0s interval")
+	print("  - physics-tick: 0.02s interval")
+	print("  - second: 1.0s interval")
+	print("  - minute: 60 second ticks")
+	print("  - hour: 60 minute ticks")
+	print("  - day: 24 hour ticks")
+	print("  - custom-tick: 0.5s accumulated")
+
+
+## Example system using tick sources
+class ExampleTimedSystem:
+	extends System
+
+	func tick() -> TickSource:
+		# Return the tick source you want this system to use
+		return ECS.world.get_tick_source('spawner-tick')
+
+	func process(entities: Array[Entity], components: Array, delta: float) -> void:
+		# This will only run when 'spawner-tick' ticks (every 2 seconds)
+		# delta will be 2.0 for IntervalTickSource
+		print("Timed system running with delta: ", delta)
+
+
+## Example: Multiple systems sharing the same tick source
+class PhysicsSystemA:
+	extends System
+
+	func tick() -> TickSource:
+		return ECS.world.get_tick_source('physics-tick')
+
+	func process(entities: Array[Entity], components: Array, delta: float) -> void:
+		# Runs every 0.02 seconds
+		pass
+
+
+class PhysicsSystemB:
+	extends System
+
+	func tick() -> TickSource:
+		return ECS.world.get_tick_source('physics-tick')
+
+	func process(entities: Array[Entity], components: Array, delta: float) -> void:
+		# Also runs every 0.02 seconds, SYNCHRONIZED with PhysicsSystemA
+		pass
+
+
+## Example: Daily event system
+class DailyRewardSystem:
+	extends System
+
+	func tick() -> TickSource:
+		return ECS.world.get_tick_source('day')
+
+	func process(entities: Array[Entity], components: Array, delta: float) -> void:
+		# This only runs once per 24 in-game hours
+		grant_daily_rewards()
+
+	func grant_daily_rewards():
+		print("Granting daily rewards!")


### PR DESCRIPTION
This commit adds a comprehensive tick source system that allows systems to run at specific intervals or rates, with support for shared tick sources to synchronize multiple systems.

Features:
- Base TickSource class that can be extended for custom timing behaviors
- IntervalTickSource for fixed-interval timing (returns fixed delta)
- AccumulatedTickSource for interval timing with actual accumulated delta
- RateFilterTickSource for frame-based sampling of other tick sources
- World-level tick source registry with convenience methods
- System.tick() method to specify tick source (cached during setup)
- Zero overhead for systems without tick sources (fast path)
- Synchronization guarantees for systems sharing tick sources
- Support for hierarchical timing (e.g., second -> minute -> hour)

Breaking Changes:
- None - fully backward compatible. Systems without tick() override continue using frame delta.

New APIs:
- World.register_tick_source(tick_source, name) - Register a tick source
- World.get_tick_source(name) - Get a registered tick source
- World.create_interval_tick_source(interval, name) - Create interval tick source
- World.create_rate_filter(rate, source_name, name) - Create rate filter
- System.tick() -> TickSource - Override to specify tick source

Files Added:
- addons/gecs/ecs/tick_source.gd - Base tick source class
- addons/gecs/ecs/interval_tick_source.gd - Fixed interval timing
- addons/gecs/ecs/accumulated_tick_source.gd - Accumulated time timing
- addons/gecs/ecs/rate_filter_tick_source.gd - Frame-based sampling
- addons/gecs/tests/core/test_tick_sources.gd - Comprehensive tests
- addons/gecs/tests/core/test_tick_source_system.gd - Test helper
- addons/gecs/tests/core/test_counting_system.gd - Test helper
- example/systems/s_timed_spawner.gd - Example timed spawner
- example/tick_source_setup_example.gd - Setup examples

Files Modified:
- addons/gecs/ecs/system.gd - Added tick() method and caching
- addons/gecs/ecs/world.gd - Added tick source registry and process() updates

Testing:
- 20+ unit tests covering all tick source types
- Integration tests for World and System
- Tests for synchronization and hierarchical timing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible tick source system: pass-through, fixed-interval, accumulated, and rate-filtered timing options.
  * World can register, create, and expose named tick sources; systems can bind to and cache a tick source to control when they run.

* **Tests**
  * Added comprehensive test suite covering tick sources, world registration, system integration, timing hierarchies, and reset behavior.

* **Documentation**
  * Added examples and sample systems demonstrating setup and common usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->