### PR TITLE
Improve getting started docs: clarify entity scene creation

### DIFF
--- a/addons/gecs/docs/GETTING_STARTED.md
+++ b/addons/gecs/docs/GETTING_STARTED.md
@@ -22,11 +22,15 @@ This guide will walk you through creating a simple player entity with health and
 
 ## 🎮 Step 2: Your First Entity (2 minutes)
 
-Entities in GECS extend Godot's `Node` class and must be created as **scenes** (prefabs) to work with Godot's scene tree.
+Entities in GECS extend Godot's `Node` class. You have two options for creating entities:
 
-> ⚠️ **Important**: Since `Entity` extends `Node` (not `Node3D` or `Node2D`), you need to create a scene with the appropriate node type as the root to access spatial properties like position, rotation, etc.
+### **Option A: Scene-based Entities** (For spatial properties)
 
-### Create the Entity Scene
+Use this when you need access to `Node3D` or `Node2D` properties like position, rotation, scale, or want to add visual children (sprites, meshes, etc.).
+
+> ⚠️ **Key Point**: `Entity` extends `Node` (not `Node3D` or `Node2D`), so create a scene with the appropriate spatial node type as the root, then attach your entity script to it.
+
+**Steps:**
 
 1. **Create a new scene** in Godot:
    - Click `Scene > New Scene` or press `Ctrl+N`
@@ -39,8 +43,6 @@ Entities in GECS extend Godot's `Node` class and must be created as **scenes** (
 
 3. **Save the scene**:
    - Save as `e_player.tscn` in your scenes folder
-
-### Create the Entity Script
 
 **File: `e_player.gd`**
 
@@ -56,7 +58,25 @@ func on_ready():
         c_trs.position = self.global_position
 ```
 
-> 💡 **What's happening?** Entities are containers for components. By creating a `Node3D` scene with the `Player` (Entity) script attached, we can access spatial properties like `global_position`. The entity syncs its scene position with the ECS transform component.
+> 💡 **Use case**: Players, enemies, projectiles, or anything that needs a position in your game world.
+
+### **Option B: Code-based Entities** (Pure data containers)
+
+Use this when you DON'T need spatial properties and just want a pure data container (e.g., game managers, abstract systems, timers).
+
+```gdscript
+# Just extend Entity directly
+class_name GameManager
+extends Entity
+
+# No scene needed - instantiate with GameManager.new()
+```
+
+> 💡 **Use case**: Game state managers, quest trackers, inventory systems, or any non-spatial game logic.
+
+---
+
+**For this tutorial**, we'll use **Option A** (scene-based) since we want our player to move around the screen with a position.
 
 ## 📦 Step 3: Your First Components (1 minute)
 
@@ -187,7 +207,7 @@ func _process(delta):
 
 **Run your project!** 🎉 You now have a working ECS setup where the player entity moves across the screen and bounces off the edges! The MovementSystem updates entity positions based on their velocity components.
 
-> 💡 **Scene-based entities**: Notice we load and instantiate the `e_player.tscn` scene instead of calling `Player.new()`. This is required because entities need to be part of Godot's scene tree to access spatial properties.
+> 💡 **Scene-based entities**: Notice we load and instantiate the `e_player.tscn` scene instead of calling `Player.new()`. This is required because we need access to spatial properties (position). For entities that don't need spatial properties, `Entity.new()` works fine.
 
 ## 🎯 What You Just Built
 
@@ -289,10 +309,11 @@ Try adding these to your moving player:
 
 ### Can't access position/rotation properties?
 
-- ⚠️ **Entity extends Node, not Node3D**: You must create a scene with `Node3D` (3D) or `Node2D` (2D) as the root node type
+- ⚠️ **Entity extends Node, not Node3D**: To access spatial properties, create a scene with `Node3D` (3D) or `Node2D` (2D) as the root node type
 - Attach your entity script (that extends `Entity`) to the Node3D/Node2D root
-- **Don't use** `Entity.new()` or `Player.new()` - always instantiate from a scene file
-- See Step 2 for the correct scene creation workflow
+- Load and instantiate the scene file (don't use `.new()` for spatial entities)
+- **If you don't need spatial properties**: Using `Entity.new()` is perfectly fine for pure data containers
+- See Step 2 for both entity creation approaches
 
 ### Errors in console?
 

--- a/addons/gecs/docs/GETTING_STARTED.md
+++ b/addons/gecs/docs/GETTING_STARTED.md
@@ -20,9 +20,27 @@ This guide will walk you through creating a simple player entity with health and
 
 > 💡 **Quick Check**: If you see errors, make sure `ECS` appears in `Project > Project Settings > AutoLoad`
 
-## 🎮 Step 2: Your First Entity (1 minute)
+## 🎮 Step 2: Your First Entity (2 minutes)
 
-Create a new scene and script for your player entity:
+Entities in GECS extend Godot's `Node` class and must be created as **scenes** (prefabs) to work with Godot's scene tree.
+
+> ⚠️ **Important**: Since `Entity` extends `Node` (not `Node3D` or `Node2D`), you need to create a scene with the appropriate node type as the root to access spatial properties like position, rotation, etc.
+
+### Create the Entity Scene
+
+1. **Create a new scene** in Godot:
+   - Click `Scene > New Scene` or press `Ctrl+N`
+   - Select **"Node3D"** as the root node type (for 3D games) or **"Node2D"** (for 2D games)
+   - Rename the root node to `Player`
+
+2. **Attach the entity script**:
+   - With the root node selected, click the "Attach Script" button (📄+ icon)
+   - Save as `e_player.gd`
+
+3. **Save the scene**:
+   - Save as `e_player.tscn` in your scenes folder
+
+### Create the Entity Script
 
 **File: `e_player.gd`**
 
@@ -38,7 +56,7 @@ func on_ready():
         c_trs.position = self.global_position
 ```
 
-> 💡 **What's happening?** Entities are containers for components. We're creating a player entity that will sync its transform with the component system.
+> 💡 **What's happening?** Entities are containers for components. By creating a `Node3D` scene with the `Player` (Entity) script attached, we can access spatial properties like `global_position`. The entity syncs its scene position with the ECS transform component.
 
 ## 📦 Step 3: Your First Components (1 minute)
 
@@ -126,6 +144,12 @@ func process(entities: Array[Entity], components: Array, delta: float):
 
 Now let's put it all together in a main scene:
 
+### Create Main Scene
+
+1. **Create a new scene** with a `Node` as the root
+2. **Add a World node** as a child (Add Child Node > search for "World")
+3. **Attach this script** to the root node:
+
 **File: `main.gd`**
 
 ```gdscript
@@ -136,17 +160,21 @@ extends Node
 
 func _ready():
     ECS.world = world
-    
-    # Create a moving player entity
-    var e_player = Player.new()
+
+    # Load and instantiate the player entity scene
+    var player_scene = preload("res://e_player.tscn")  # Adjust path as needed
+    var e_player = player_scene.instantiate() as Player
+
+    # Add components to the entity
     e_player.add_components([
         C_Health.new(100),
         C_Transform.new(),
         C_Velocity.new(Vector3(2, 0, 0))  # Move right at 2 units/second
     ])
+
     add_child(e_player)  # Add to scene tree
     ECS.world.add_entity(e_player)  # Add to ECS world
-    
+
     # Create the movement system
     var movement_system = MovementSystem.new()
     ECS.world.add_system(movement_system)
@@ -158,6 +186,8 @@ func _process(delta):
 ```
 
 **Run your project!** 🎉 You now have a working ECS setup where the player entity moves across the screen and bounces off the edges! The MovementSystem updates entity positions based on their velocity components.
+
+> 💡 **Scene-based entities**: Notice we load and instantiate the `e_player.tscn` scene instead of calling `Player.new()`. This is required because entities need to be part of Godot's scene tree to access spatial properties.
 
 ## 🎯 What You Just Built
 
@@ -256,6 +286,13 @@ Try adding these to your moving player:
 - Verify components are added to the entity via `define_components()` or Inspector
 - Make sure the system is added to the world
 - Ensure transform synchronization is called in entity's `on_ready()`
+
+### Can't access position/rotation properties?
+
+- ⚠️ **Entity extends Node, not Node3D**: You must create a scene with `Node3D` (3D) or `Node2D` (2D) as the root node type
+- Attach your entity script (that extends `Entity`) to the Node3D/Node2D root
+- **Don't use** `Entity.new()` or `Player.new()` - always instantiate from a scene file
+- See Step 2 for the correct scene creation workflow
 
 ### Errors in console?
 


### PR DESCRIPTION
- Add explicit explanation that Entity extends Node, not Node3D/Node2D
- Add step-by-step instructions for creating entity scenes with proper node types
- Update Step 5 to use scene instantiation (preload/instantiate) instead of .new()
- Add troubleshooting section for spatial property access issues
- Clarify that entities must be created as prefab scenes to access position/rotation

This addresses confusion around why users can't access position properties
when creating entities, as Entity extends Node which lacks spatial properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated getting started guide with expanded entity-creation options (scene-based vs code-based) and step-by-step workflows.
  * Clarified when to use scene-based entities for spatial properties and when code-only entities are appropriate.
  * Enhanced troubleshooting for accessing position/rotation and synchronization with the scene.
  * Improved code examples, run/build guidance, and adjusted step durations for more accurate time expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->