### PR TITLE
Checking if handlers are connected before disconnecting them.

### DIFF
--- a/addons/gecs/ecs/world.gd
+++ b/addons/gecs/ecs/world.gd
@@ -392,10 +392,14 @@ func disable_entity(entity) -> Entity:
 	entity_disabled.emit(entity)
 	_worldLogger.debug("disable_entity Disabling Entity: ", entity)
 
-	entity.component_added.disconnect(_on_entity_component_added)
-	entity.component_removed.disconnect(_on_entity_component_removed)
-	entity.relationship_added.disconnect(_on_entity_relationship_added)
-	entity.relationship_removed.disconnect(_on_entity_relationship_removed)
+	if entity.component_added.is_connected(_on_entity_component_added):
+		entity.component_added.disconnect(_on_entity_component_added)
+	if entity.component_removed.is_connected(_on_entity_component_removed):
+		entity.component_removed.disconnect(_on_entity_component_removed)
+	if entity.relationship_added.is_connected(_on_entity_relationship_added):
+		entity.relationship_added.disconnect(_on_entity_relationship_added)
+	if entity.relationship_removed.is_connected(_on_entity_relationship_removed):
+		entity.relationship_removed.disconnect(_on_entity_relationship_removed)
 	entity.on_disable()
 	entity.set_process(false)
 	entity.set_physics_process(false)


### PR DESCRIPTION
Hi, looks like we need these methods.

I use node pooling in my scenes and instead of calling `remove_entity()` (which is calling `queue_free`, which I want to avoid) - I call enable/disable often. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when disabling entities by adding additional safety checks to prevent runtime errors during the disable process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->