### PR TITLE
Fix logger.warn() call to use correct warning() method name

### DIFF
--- a/addons/gecs/ecs/world.gd
+++ b/addons/gecs/ecs/world.gd
@@ -403,7 +403,7 @@ func remove_entity(entity) -> void:
 	if erase_idx >= 0:
 		entities.remove_at(erase_idx)
 	else:
-		_worldLogger.warn("remove_entity: entity not found in entities array: ", entity)
+		_worldLogger.warning("remove_entity: entity not found in entities array: ", entity)
 
 	# Only disconnect signals if they're actually connected
 	if entity.component_added.is_connected(_on_entity_component_added):


### PR DESCRIPTION
Fixes a recent typo function name.
```
world.gd:406 calls _worldLogger.warn() but GECSLogger only defines warning(). 
```
This crashes at runtime when remove_entity is called on an entity not found in the entities array.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging level for entity removal error messages to improve consistency in error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->