### PR TITLE
Fix stale tree_exited callback nulling new world on scene restart

### DIFF
--- a/addons/gecs/ecs/ecs.gd
+++ b/addons/gecs/ecs/ecs.gd
@@ -38,7 +38,7 @@ var world: World:
 		return world
 	set(value):
 		# Disconnect old world to prevent stale tree_exited callback
-		if world and world.is_connected("tree_exited", _on_world_exited):
+		if is_instance_valid(world) and world.is_connected("tree_exited", _on_world_exited):
 			world.disconnect("tree_exited", _on_world_exited)
 		# Add the new world to the scenes
 		world = value


### PR DESCRIPTION
Fixes https://github.com/csprance/gecs/issues/90


When replacing scenes that each set ECS.world, the old world's tree_exited callback fires after the new world is assigned, nulling the active reference and crashing any system that accesses ECS.world.

Root cause: The world setter connects tree_exited → _on_world_exited on each new world but never disconnects it from the old world. During a scene transition:

  1. New scene sets ECS.world = new_world
  2. Old scene calls queue_free() (deferred)
  3. Old World node exits tree → _on_world_exited fires → ECS.world = null
  4. Systems access ECS.world → crash (Nonexistent function in base 'Nil')

  Fix: Disconnect the old world's tree_exited signal before assigning the new value in the setter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved world switching in ECS to properly clean up signal connections, preventing callback issues during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->