### PR TITLE
Fix links for network documentation on repository

### DIFF
--- a/addons/gecs/README.md
+++ b/addons/gecs/README.md
@@ -71,10 +71,10 @@
 
 | Topic               | Document                                                            | Description                                        |
 | ------------------- | ------------------------------------------------------------------- | -------------------------------------------------- |
-| **Overview**        | [GECS Network Addon](../gecs_network/README.md)                     | Multiplayer sync, transport providers (ENet/Steam) |
-| **Configuration**   | [Configuration & NetAdapter](../gecs_network/docs/configuration.md) | NetAdapter, priority tiers, ProjectSettings        |
-| **Examples**        | [Examples](../gecs_network/docs/examples.md)                        | Players, enemies, projectiles, abilities           |
-| **Troubleshooting** | [Troubleshooting](../gecs_network/docs/troubleshooting.md)          | Common networking issues and migration guide       |
+| **Overview**        | [GECS Network Addon](network/README.md)                     | Multiplayer sync, transport providers (ENet/Steam) |
+| **Configuration**   | [Configuration & NetAdapter](docs/network/configuration.md) | NetAdapter, priority tiers, ProjectSettings        |
+| **Examples**        | [Examples](docs/network/examples.md)                        | Players, enemies, projectiles, abilities           |
+| **Troubleshooting** | [Troubleshooting](docs/network/troubleshooting.md)          | Common networking issues and migration guide       |
 
 ### Optimization & Debugging
 

--- a/addons/gecs/README.md
+++ b/addons/gecs/README.md
@@ -36,7 +36,7 @@
 
 ### Networking (Optional addon)
 
-- **[GECS Network Addon](../gecs_network/README.md)** - Multiplayer synchronization for GECS entities. Supports **transport providers** (ENet, Steam, or custom backends) that can be swapped without changing game code. See the addon docs for [Configuration & NetAdapter](../gecs_network/docs/configuration.md), [Examples](../gecs_network/docs/examples.md), and [Troubleshooting](../gecs_network/docs/troubleshooting.md).
+- **[GECS Network Addon](network/README.md)** - Multiplayer synchronization for GECS entities. Supports **transport providers** (ENet, Steam, or custom backends) that can be swapped without changing game code. See the addon docs for [Configuration & NetAdapter](docs/network/configuration.md), [Examples](docs/network/examples.md), and [Troubleshooting](docs/network/troubleshooting.md).
 
 ### Optimization & Advanced (As needed)
 

--- a/addons/gecs/network/README.md
+++ b/addons/gecs/network/README.md
@@ -88,7 +88,7 @@ addons/gecs_network/
 ├── transports/
 │   ├── enet_transport_provider.gd     # Default ENet transport
 │   └── steam_transport_provider.gd    # Steam transport (requires GodotSteam)
-├── docs/
+├── ../docs/network/
 │   ├── components.md              # CN_NetworkIdentity, CN_NetSync, CN_NativeSync, markers
 │   ├── architecture.md            # Handler architecture, sync pipeline diagram
 │   ├── authority.md               # Authority query patterns (CN_LocalAuthority, CN_ServerAuthority)
@@ -113,16 +113,16 @@ addons/gecs_network/
 
 ## Documentation
 
-- [Components](docs/components.md)
-- [Architecture](docs/architecture.md)
-- [Authority](docs/authority.md)
-- [Configuration](docs/configuration.md)
-- [Sync Patterns](docs/sync-patterns.md)
-- [Custom Sync Handlers](docs/custom-sync-handlers.md)
-- [Best Practices](docs/best-practices.md)
-- [Examples](docs/examples.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Migration Guide](docs/migration-v1-to-v2.md)
+- [Components](../docs/network/components.md)
+- [Architecture](../docs/network/architecture.md)
+- [Authority](../docs/network/authority.md)
+- [Configuration](../docs/network/configuration.md)
+- [Sync Patterns](../docs/network/sync-patterns.md)
+- [Custom Sync Handlers](../docs/network/custom-sync-handlers.md)
+- [Best Practices](../docs/network/best-practices.md)
+- [Examples](../docs/network/examples.md)
+- [Troubleshooting](../docs/network/troubleshooting.md)
+- [Migration Guide](../docs/network/migration-v1-to-v2.md)
 
 ## License
 


### PR DESCRIPTION
Hi! I was trying to navigate the documentation of the network addon and found most links pointed to missing pages. I've quickly fixed most of these links in `.md`.

Note I don't know what's the state of docs references inside Godot and the codebase, might as well be worth it checking that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized networking addon documentation paths and updated internal navigation links to reflect improved documentation directory structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csprance/gecs/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->