### PR TITLE
Add light theme for debugger

### DIFF
--- a/addons/gecs/debug/gecs_editor_debugger_tab.gd
+++ b/addons/gecs/debug/gecs_editor_debugger_tab.gd
@@ -50,6 +50,7 @@ const ICON_PIN = "📌"  # Pinned item icon
 
 
 func _ready() -> void:
+	_match_theme_to_editor_luminance()
 	_update_debug_mode_overlay()
 	if system_tree:
 		# Eight columns: name, group, current time, min, max, avg, status, order
@@ -199,6 +200,19 @@ func _process(delta: float) -> void:
 		return
 	_poll_elapsed = 0.0
 	_poll_expanded_entities()
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_THEME_CHANGED:
+		_match_theme_to_editor_luminance()
+
+
+func _match_theme_to_editor_luminance() -> void:
+	var editor_base_color: Color = get_theme_color("base_color", "Editor")
+	if editor_base_color.get_luminance() < 0.5:
+		theme = null # No theme defaults to a dark style
+	else:
+		theme = load("uid://c1k1244qg6usg") # Load: gecs_editor_debugger_tab_light_theme.tres
 
 
 func _update_debug_mode_overlay() -> void:

--- a/addons/gecs/debug/gecs_editor_debugger_tab_light_theme.tres
+++ b/addons/gecs/debug/gecs_editor_debugger_tab_light_theme.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Theme" format=3 uid="uid://c1k1244qg6usg"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_csn7a"]
+bg_color = Color(0.9529412, 0.9529412, 0.9529412, 1)
+
+[resource]
+Tree/styles/panel = SubResource("StyleBoxFlat_csn7a")


### PR DESCRIPTION
<img width="1202" height="832" alt="End result" src="https://github.com/user-attachments/assets/c71ccbb1-cd0e-4318-b7b7-97fa2475cf56" />

The debugger actually adapts well to different themes, specially when docked to the bottom. It is just that, when it gets popped out, the Tree node completely misses the theme, so that node's style is the only one affected by this.

I am no UI magician, so my simple solution has been applying a custom [Theme](https://docs.godotengine.org/en/stable/classes/class_theme.html#theme) to the debugger scene if the luminance of the editor base color is closer to white than black. If that's not the case, the theme is left as null, which looks fine on dark mode. All of this happens on `_ready` and on a  `_notification` of theme change.

Closes #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debugger tab now automatically adapts its theme to match the editor's appearance, supporting both dark and light modes.
  * Theme adjustments are applied dynamically when the editor theme changes, ensuring consistent visual styling across the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csprance/gecs/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->