### PR TITLE
Add Injection of CN_RemoteEntity 

### DIFF
--- a/addons/gecs/network/spawn_manager.gd
+++ b/addons/gecs/network/spawn_manager.gd
@@ -253,6 +253,10 @@ func _inject_authority_markers(entity: Entity, net_id: CN_NetworkIdentity) -> vo
 		or (_ns.net_adapter.is_server() and net_id.is_server_owned())
 	):
 		entity.add_component(CN_LocalAuthority.new())
+	
+	# CN_RemoteEntity: an entity owned by a remote peer (peer_id != multiplayer unique ID)
+	if net_id.peer_id != _ns.net_adapter.get_multiplayer().get_unique_id():
+		entity.add_component(CN_RemoteEntity.new())
 
 
 ## Find a component on an entity by its type name string.

--- a/addons/gecs/network/spawn_manager.gd
+++ b/addons/gecs/network/spawn_manager.gd
@@ -241,11 +241,16 @@ func _inject_authority_markers(entity: Entity, net_id: CN_NetworkIdentity) -> vo
 	# Remove stale markers first -- idempotent re-spawn safety
 	entity.remove_component(CN_LocalAuthority)
 	entity.remove_component(CN_ServerAuthority)
+	entity.remove_component(CN_RemoteEntity)
 
 	# CN_ServerAuthority: server-owned entities (peer_id == 0) on ALL peers
 	if net_id.is_server_owned():
 		entity.add_component(CN_ServerAuthority.new())
-
+	
+	# CN_RemoteEntity: an entity owned by a remote peer (peer_id != multiplayer unique ID)
+	elif net_id.peer_id != _ns.net_adapter.get_multiplayer().get_unique_id():
+		entity.add_component(CN_RemoteEntity.new())
+	
 	# CN_LocalAuthority: local peer's own entity
 	# Also: server gets CN_LocalAuthority on server-owned entities (server "is local" for them)
 	if (
@@ -253,10 +258,6 @@ func _inject_authority_markers(entity: Entity, net_id: CN_NetworkIdentity) -> vo
 		or (_ns.net_adapter.is_server() and net_id.is_server_owned())
 	):
 		entity.add_component(CN_LocalAuthority.new())
-	
-	# CN_RemoteEntity: an entity owned by a remote peer (peer_id != multiplayer unique ID)
-	if net_id.peer_id != _ns.net_adapter.get_multiplayer().get_unique_id():
-		entity.add_component(CN_RemoteEntity.new())
 
 
 ## Find a component on an entity by its type name string.


### PR DESCRIPTION
Implement flagging entities with CN_RemoteEntity as described here: [Authority Query Reference](https://github.com/csprance/gecs/blob/main/addons/gecs/docs/network/examples.md#authority-query-reference)

It does not appear that the addon currently flags any entities with CN_RemoteEntity, only CN_LocalAuthority and CN_ServerAuthority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved multiplayer ownership tracking so entities controlled by remote players are identified and synchronized more reliably, reducing desyncs and making multiplayer behavior and state consistency more dependable during online sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->