### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ MIT - See [LICENSE](LICENSE) for details.
 
 _GECS is provided as-is. If it breaks, you get to keep both pieces._
 
-[![Star History Chart](https://api.star-history.com/svg?repos=csprance/gecs&type=Date)](https://star-history.com/#csprance/gecs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=csprance/gecs&type=Date)](https://star-history.dera.page/#csprance/gecs&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and renders as a broken image, a fix is necessary. This switches the chart to a working star history service that is not affected by the GitHub stargazer API restrictions, so the chart displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History Chart image and link to use the new hosting service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->